### PR TITLE
added check to skip test if dependabot ran it and it contains urls, a…

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -26,7 +26,39 @@ on:
 
 
 jobs:
+
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      allow_test: ${{ steps.set.outputs.allow_test }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Detect internal dependencies
+        id: set
+        run: |
+          # Default to true
+          echo "allow_test=true" >> $GITHUB_OUTPUT
+
+          # Only run detection if Dependabot triggered this
+          if [ "${GITHUB_ACTOR}" != "dependabot[bot]" ]; then
+            echo "allow_test=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # If Dependabot triggered, block if URL contains "renalreg"
+          if [ -f requirements.txt ] && grep -qE 'github\.com[:/]+renalreg/' requirements.txt; then
+            echo "allow_test=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -f pyproject.toml ] && grep -qE 'github\.com[:/]+renalreg/' pyproject.toml; then
+            echo "allow_test=false" >> $GITHUB_OUTPUT
+          fi
+
   test:
+    needs: detect
+    if: ${{ needs.detect.outputs.allow_test == 'true' }}
     runs-on: ${{ matrix.platform }}
 
     strategy:


### PR DESCRIPTION
added check to skip test if dependabot ran it and it contains urls, assuming they are private, I have added to this as dependabot often triggers test flows, webapi, ursus etc but will fail as keys are not passed to dependabot for safety, this should check if its ran by dependabot and if it contains a potentially private url in a dep file