### PR TITLE
RD-4

### DIFF
--- a/.github/scripts/update_badges.py
+++ b/.github/scripts/update_badges.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import os
+import re
+from pathlib import Path
+import yaml
+
+# -----------------------
+# Config
+# -----------------------
+README_FILE = Path(r".\README.md")
+# Look for <badges> ... </badges> block in README
+BADGES_TAG_RE = re.compile(r"<div class=\"badges\">.*?</div>", re.DOTALL)
+BADGES_CONFIG_FILE = Path(r".\badges.yml")
+
+WORKFLOWS_DIR = Path(r".\.github\workflows")
+PYPI_PACKAGE_NAME = os.environ.get("PYPI_PACKAGE_NAME", None)
+
+
+def detect_workflows():
+    if not WORKFLOWS_DIR.exists():
+        return []
+
+    workflows = []
+    for wf in WORKFLOWS_DIR.glob("*.yml"):
+        name = wf.stem
+        workflows.append(name)
+    return workflows
+
+
+def load_optional_badges():
+    if not BADGES_CONFIG_FILE.exists():
+        return []
+
+    with BADGES_CONFIG_FILE.open("r") as f:
+        try:
+            data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"Error parsing {BADGES_CONFIG_FILE}: {e}")
+            return [], None
+
+    # Expecting a list of badge strings under "badges"
+    if isinstance(data, dict) and "badges" in data and isinstance(data["badges"], list):
+        return data["badges"], data
+    return [], data
+
+
+def build_badge_block(repo_full_name):
+    badges = []
+
+    workflows = detect_workflows()
+    for wf_name in workflows:
+        if wf_name == "python_test.yml":
+            badge_html = ""
+        else:
+            continue
+
+        badges.append(badge_html)
+
+    # Add static badges
+
+    hardcoded_badges, data = load_optional_badges()
+    standard_badges = {
+        "issues": f"[![Issues](https://img.shields.io/github/issues/{repo_full_name})](https://github.com/{repo_full_name}/issues)",
+        "dependencies": f"[![Dependencies](https://img.shields.io/librariesio/github/{repo_full_name})](https://libraries.io/github/{repo_full_name})",
+        "vulnerabilities": f"[![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/{repo_full_name})](https://snyk.io/test/github/{repo_full_name})",
+        "license": f"[![License](https://img.shields.io/github/license/{repo_full_name})](https://github.com/{repo_full_name}/blob/main/LICENSE)",
+        "stars": f"[![Stars](https://img.shields.io/github/stars/{repo_full_name})](https://github.com/{repo_full_name}/stargazers)",
+        "codecov": f"[![Coverage](https://codecov.io/gh/{repo_full_name}/branch/main/graph/badge.svg)](https://codecov.io/gh/{repo_full_name})",
+    }
+
+    selected_standard_badges = [
+        value
+        for key, value in standard_badges.items()
+        if key not in data.get("disable", [])
+    ]
+
+    selectable_badges = {
+        "forks": f"[![Forks](https://img.shields.io/github/forks/{repo_full_name})](https://github.com/{repo_full_name}/network/members)",
+    }
+
+    enabled_badges = [
+        value
+        for key, value in selectable_badges.items()
+        if key in data.get("enable", [])
+    ]
+
+    badges.extend(selected_standard_badges)
+    badges.extend(enabled_badges)
+    badges.extend(hardcoded_badges)
+
+    # pypi badges
+    if PYPI_PACKAGE_NAME:
+        badges.append(
+            f"[![PyPI Version](https://img.shields.io/pypi/v/{PYPI_PACKAGE_NAME})](https://pypi.org/project/{PYPI_PACKAGE_NAME})"
+        )
+        badges.append(
+            f"[![Python Versions](https://img.shields.io/pypi/pyversions/{PYPI_PACKAGE_NAME})](https://pypi.org/project/{PYPI_PACKAGE_NAME})"
+        )
+
+    # Join all badges with a space
+    return "\n".join(badges)
+
+
+def update_readme(repo_full_name):
+    if not README_FILE.exists():
+        readme_content = '<div class="badges">\n</div>\n'
+    else:
+        readme_content = README_FILE.read_text()
+
+    badge_block = build_badge_block(repo_full_name)
+    new_block = f'<div class="badges">\n\n{badge_block}\n\n</div>'
+
+    if BADGES_TAG_RE.search(readme_content):
+        updated_content = BADGES_TAG_RE.sub(new_block, readme_content)
+    else:
+        # If no <badges> tag exists, append it at the top
+        updated_content = new_block + "\n\n" + readme_content
+
+    README_FILE.write_text(updated_content)
+
+
+# -----------------------
+# Main
+# -----------------------
+if __name__ == "__main__":
+    # Infer repository name from environment if running in GitHub Actions
+    GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "renalreg/ukrdc-sqla")
+    update_readme(GITHUB_REPOSITORY)

--- a/.github/scripts/update_badges.py
+++ b/.github/scripts/update_badges.py
@@ -1,133 +1,164 @@
 #!/usr/bin/env python3
 import os
 import re
+import argparse
 from pathlib import Path
+from typing import Dict, List
+
+import click
 import yaml
 
-# -----------------------
-# Config
-# -----------------------
-README_FILE = Path(r".\README.md")
-# Look for <badges> ... </badges> block in README
+README_FILE = Path("README.md")
+BADGES_CONFIG_FILE = Path("badges.yml")
+WORKFLOWS_DIR = Path(".github/workflows")
+
 BADGES_TAG_RE = re.compile(r"<div class=\"badges\">.*?</div>", re.DOTALL)
-BADGES_CONFIG_FILE = Path(r".\badges.yml")
 
-WORKFLOWS_DIR = Path(r".\.github\workflows")
-PYPI_PACKAGE_NAME = os.environ.get("PYPI_PACKAGE_NAME", None)
+PYPI_PACKAGE_NAME = os.environ.get("PYPI_PACKAGE_NAME")
 
 
-def detect_workflows():
+# ---------------------------------------------------------
+# Badge Registry
+# ---------------------------------------------------------
+
+
+def badge_registry(repo: str, visibility: str) -> Dict[str, str]:
+    base = {
+        "issues": f"[![Issues](https://img.shields.io/github/issues/{repo})](https://github.com/{repo}/issues)",
+        "license": f"[![License](https://img.shields.io/github/license/{repo})](https://github.com/{repo}/blob/main/LICENSE)",
+        "stars": f"[![Stars](https://img.shields.io/github/stars/{repo})](https://github.com/{repo}/stargazers)",
+        "forks": f"[![Forks](https://img.shields.io/github/forks/{repo})](https://github.com/{repo}/network/members)",
+        "dependencies": f"[![Dependencies](https://img.shields.io/librariesio/github/{repo})](https://libraries.io/github/{repo})",
+        "vulnerabilities": f"[![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/{repo})](https://snyk.io/test/github/{repo})",
+        "codecov": f"[![Coverage](https://codecov.io/gh/{repo}/branch/main/graph/badge.svg)](https://codecov.io/gh/{repo})",
+    }
+
+    # Default sets differ by visibility
+    if visibility == "private":
+        defaults = ["issues", "license"]
+    else:  # public
+        defaults = ["issues", "license", "stars", "dependencies", "vulnerabilities"]
+
+    return {k: v for k, v in base.items() if k in defaults}
+
+
+# ---------------------------------------------------------
+# Workflow badges
+# ---------------------------------------------------------
+
+
+def detect_workflows(repo: str) -> Dict[str, str]:
+    badges = {}
     if not WORKFLOWS_DIR.exists():
-        return []
+        return badges
 
-    workflows = []
     for wf in WORKFLOWS_DIR.glob("*.yml"):
         name = wf.stem
-        workflows.append(name)
-    return workflows
+        badges[f"workflow:{name}"] = (
+            f"[![{name}](https://github.com/{repo}/actions/workflows/{wf.name}/badge.svg)]"
+            f"(https://github.com/{repo}/actions/workflows/{wf.name})"
+        )
+    return badges
 
 
-def load_optional_badges():
+# ---------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------
+
+
+def load_config() -> Dict:
     if not BADGES_CONFIG_FILE.exists():
-        return [], None
+        return {}
 
-    with BADGES_CONFIG_FILE.open("r") as f:
-        try:
-            data = yaml.safe_load(f)
-        except yaml.YAMLError as e:
-            print(f"Error parsing {BADGES_CONFIG_FILE}: {e}")
-            return [], None
-
-    # Expecting a list of badge strings under "badges"
-    if isinstance(data, dict) and "badges" in data and isinstance(data["badges"], list):
-        return data["badges"], data
-    return [], data
+    with BADGES_CONFIG_FILE.open() as f:
+        return yaml.safe_load(f) or {}
 
 
-def build_badge_block(repo_full_name):
-    badges = []
+# ---------------------------------------------------------
+# Badge builder
+# ---------------------------------------------------------
 
-    workflows = detect_workflows()
-    for wf_name in workflows:
-        if wf_name == "python_test.yml":
-            badge_html = ""
-        else:
-            continue
 
-        badges.append(badge_html)
+def build_badges(repo: str, visibility: str) -> List[str]:
+    config = load_config()
 
-    # Add static badges
+    registry = badge_registry(repo, visibility)
+    workflow_badges = detect_workflows(repo)
 
-    hardcoded_badges, data = load_optional_badges()
-    standard_badges = {
-        "issues": f"[![Issues](https://img.shields.io/github/issues/{repo_full_name})](https://github.com/{repo_full_name}/issues)",
-        "dependencies": f"[![Dependencies](https://img.shields.io/librariesio/github/{repo_full_name})](https://libraries.io/github/{repo_full_name})",
-        "vulnerabilities": f"[![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/{repo_full_name})](https://snyk.io/test/github/{repo_full_name})",
-        "license": f"[![License](https://img.shields.io/github/license/{repo_full_name})](https://github.com/{repo_full_name}/blob/main/LICENSE)",
-        "stars": f"[![Stars](https://img.shields.io/github/stars/{repo_full_name})](https://github.com/{repo_full_name}/stargazers)",
-        "codecov": f"[![Coverage](https://codecov.io/gh/{repo_full_name}/branch/main/graph/badge.svg)](https://codecov.io/gh/{repo_full_name})",
-    }
-    if data:
-        selected_standard_badges = [
-            value
-            for key, value in standard_badges.items()
-            if key not in data.get("disable", [])
-        ]
+    # Merge registries
+    registry.update(workflow_badges)
 
-        selectable_badges = {
-            "forks": f"[![Forks](https://img.shields.io/github/forks/{repo_full_name})](https://github.com/{repo_full_name}/network/members)",
-        }
+    # Apply disables
+    for key in config.get("disable", []):
+        registry.pop(key, None)
 
-        enabled_badges = [
-            value
-            for key, value in selectable_badges.items()
-            if key in data.get("enable", [])
-        ]
+    # Apply enables (things not in defaults)
+    for key in config.get("enable", []):
+        if key in workflow_badges:
+            registry[key] = workflow_badges[key]
+        elif key in badge_registry(repo, "public"):
+            registry[key] = badge_registry(repo, "public")[key]
 
-        badges.extend(selected_standard_badges)
-        badges.extend(enabled_badges)
-    else:
-        badges.extend([value for key, value in standard_badges.items()])
-    badges.extend(hardcoded_badges)
+    badges = list(registry.values())
 
-    # pypi badges
+    # Hardcoded custom badges
+    for custom in config.get("badges", []):
+        badges.append(custom)
+
+    # PyPI badges
     if PYPI_PACKAGE_NAME:
-        badges.append(
-            f"[![PyPI Version](https://img.shields.io/pypi/v/{PYPI_PACKAGE_NAME})](https://pypi.org/project/{PYPI_PACKAGE_NAME})"
+        badges.extend(
+            [
+                f"[![PyPI Version](https://img.shields.io/pypi/v/{PYPI_PACKAGE_NAME})](https://pypi.org/project/{PYPI_PACKAGE_NAME})",
+                f"[![Python Versions](https://img.shields.io/pypi/pyversions/{PYPI_PACKAGE_NAME})](https://pypi.org/project/{PYPI_PACKAGE_NAME})",
+            ]
         )
-        badges.append(
-            f"[![Python Versions](https://img.shields.io/pypi/pyversions/{PYPI_PACKAGE_NAME})](https://pypi.org/project/{PYPI_PACKAGE_NAME})"
-        )
 
-    # Join all badges with a space
-    return "\n".join(badges)
+    return badges
 
 
-def update_readme(repo_full_name):
-    if not README_FILE.exists():
-        readme_content = '<div class="badges">\n</div>\n'
+# ---------------------------------------------------------
+# README updater
+# ---------------------------------------------------------
+
+
+def update_readme(repo: str, visibility: str):
+    badge_lines = "\n".join(build_badges(repo, visibility))
+    new_block = f'<div class="badges">\n\n{badge_lines}\n\n</div>'
+
+    if README_FILE.exists():
+        content = README_FILE.read_text()
     else:
-        readme_content = README_FILE.read_text()
+        content = ""
 
-    badge_block = build_badge_block(repo_full_name)
-    new_block = f'<div class="badges">\n\n{badge_block}\n\n</div>'
-
-    if BADGES_TAG_RE.search(readme_content):
-        updated_content = BADGES_TAG_RE.sub(new_block, readme_content)
+    if BADGES_TAG_RE.search(content):
+        updated = BADGES_TAG_RE.sub(new_block, content)
     else:
-        # If no <badges> tag exists, append it at the top
-        updated_content = new_block + "\n\n" + readme_content
+        updated = new_block + "\n\n" + content
 
-    README_FILE.write_text(updated_content)
+    README_FILE.write_text(updated)
 
 
-# -----------------------
+# ---------------------------------------------------------
 # Main
-# -----------------------
+# ---------------------------------------------------------
+
+
+@click.command()
+@click.option(
+    "--visibility",
+    type=click.Choice(["public", "private"]),
+    default="private",
+    show_default=True,
+    help="Controls which default badges are included.",
+)
+def main(visibility: str):
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        raise RuntimeError("GITHUB_REPOSITORY not set")
+
+    update_readme(repo, visibility)
+
+
 if __name__ == "__main__":
-    # Infer repository name from environment if running in GitHub Actions
-    GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY")
-    if GITHUB_REPOSITORY:
-        update_readme(GITHUB_REPOSITORY)
-    else:
-        raise Exception("GITHUB_REPOSITORY environment variable not set")
+    main()

--- a/.github/scripts/update_badges.py
+++ b/.github/scripts/update_badges.py
@@ -11,11 +11,8 @@ import yaml
 README_FILE = Path("README.md")
 BADGES_CONFIG_FILE = Path("badges.yml")
 WORKFLOWS_DIR = Path(".github/workflows")
-
 BADGES_TAG_RE = re.compile(r"<div class=\"badges\">.*?</div>", re.DOTALL)
-
 PYPI_PACKAGE_NAME = os.environ.get("PYPI_PACKAGE_NAME")
-
 
 def badge_registry(repo: str, visibility: str) -> Dict[str, str]:
     base = {

--- a/.github/scripts/update_badges.py
+++ b/.github/scripts/update_badges.py
@@ -29,7 +29,7 @@ def detect_workflows():
 
 def load_optional_badges():
     if not BADGES_CONFIG_FILE.exists():
-        return []
+        return [], None
 
     with BADGES_CONFIG_FILE.open("r") as f:
         try:
@@ -67,25 +67,27 @@ def build_badge_block(repo_full_name):
         "stars": f"[![Stars](https://img.shields.io/github/stars/{repo_full_name})](https://github.com/{repo_full_name}/stargazers)",
         "codecov": f"[![Coverage](https://codecov.io/gh/{repo_full_name}/branch/main/graph/badge.svg)](https://codecov.io/gh/{repo_full_name})",
     }
+    if data:
+        selected_standard_badges = [
+            value
+            for key, value in standard_badges.items()
+            if key not in data.get("disable", [])
+        ]
 
-    selected_standard_badges = [
-        value
-        for key, value in standard_badges.items()
-        if key not in data.get("disable", [])
-    ]
+        selectable_badges = {
+            "forks": f"[![Forks](https://img.shields.io/github/forks/{repo_full_name})](https://github.com/{repo_full_name}/network/members)",
+        }
 
-    selectable_badges = {
-        "forks": f"[![Forks](https://img.shields.io/github/forks/{repo_full_name})](https://github.com/{repo_full_name}/network/members)",
-    }
+        enabled_badges = [
+            value
+            for key, value in selectable_badges.items()
+            if key in data.get("enable", [])
+        ]
 
-    enabled_badges = [
-        value
-        for key, value in selectable_badges.items()
-        if key in data.get("enable", [])
-    ]
-
-    badges.extend(selected_standard_badges)
-    badges.extend(enabled_badges)
+        badges.extend(selected_standard_badges)
+        badges.extend(enabled_badges)
+    else:
+        badges.extend([value for key, value in standard_badges.items()])
     badges.extend(hardcoded_badges)
 
     # pypi badges
@@ -124,5 +126,8 @@ def update_readme(repo_full_name):
 # -----------------------
 if __name__ == "__main__":
     # Infer repository name from environment if running in GitHub Actions
-    GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "renalreg/ukrdc-sqla")
-    update_readme(GITHUB_REPOSITORY)
+    GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY")
+    if GITHUB_REPOSITORY:
+        update_readme(GITHUB_REPOSITORY)
+    else:
+        raise Exception("GITHUB_REPOSITORY environment variable not set")

--- a/.github/scripts/update_badges.py
+++ b/.github/scripts/update_badges.py
@@ -17,11 +17,6 @@ BADGES_TAG_RE = re.compile(r"<div class=\"badges\">.*?</div>", re.DOTALL)
 PYPI_PACKAGE_NAME = os.environ.get("PYPI_PACKAGE_NAME")
 
 
-# ---------------------------------------------------------
-# Badge Registry
-# ---------------------------------------------------------
-
-
 def badge_registry(repo: str, visibility: str) -> Dict[str, str]:
     base = {
         "issues": f"[![Issues](https://img.shields.io/github/issues/{repo})](https://github.com/{repo}/issues)",
@@ -42,10 +37,6 @@ def badge_registry(repo: str, visibility: str) -> Dict[str, str]:
     return {k: v for k, v in base.items() if k in defaults}
 
 
-# ---------------------------------------------------------
-# Workflow badges
-# ---------------------------------------------------------
-
 
 def detect_workflows(repo: str) -> Dict[str, str]:
     badges = {}
@@ -61,22 +52,12 @@ def detect_workflows(repo: str) -> Dict[str, str]:
     return badges
 
 
-# ---------------------------------------------------------
-# Config loader
-# ---------------------------------------------------------
-
-
 def load_config() -> Dict:
     if not BADGES_CONFIG_FILE.exists():
         return {}
 
     with BADGES_CONFIG_FILE.open() as f:
         return yaml.safe_load(f) or {}
-
-
-# ---------------------------------------------------------
-# Badge builder
-# ---------------------------------------------------------
 
 
 def build_badges(repo: str, visibility: str) -> List[str]:
@@ -117,11 +98,6 @@ def build_badges(repo: str, visibility: str) -> List[str]:
     return badges
 
 
-# ---------------------------------------------------------
-# README updater
-# ---------------------------------------------------------
-
-
 def update_readme(repo: str, visibility: str):
     badge_lines = "\n".join(build_badges(repo, visibility))
     new_block = f'<div class="badges">\n\n{badge_lines}\n\n</div>'
@@ -137,11 +113,6 @@ def update_readme(repo: str, visibility: str):
         updated = new_block + "\n\n" + content
 
     README_FILE.write_text(updated)
-
-
-# ---------------------------------------------------------
-# Main
-# ---------------------------------------------------------
 
 
 @click.command()

--- a/.github/workflows/badge_updater.yml
+++ b/.github/workflows/badge_updater.yml
@@ -15,7 +15,7 @@ jobs:
         id: repos
         env:
           ORG_NAME: renalreg
-          GITHUB_TOKEN: ${{ secrets.ORG_PAT }}
+          GITHUB_TOKEN: ${{  secrets.GITHUB_TOKEN  }}
         run: |
           echo "Fetching all non-archived repos from $ORG_NAME..."
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Trigger repository_dispatch only if readme_sync.yml exists
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_PAT }}
+          GITHUB_TOKEN: ${{  secrets.GITHUB_TOKEN  }}
         run: |
           while IFS= read -r repo; do
             [ -z "$repo" ] && continue

--- a/.github/workflows/badge_updater.yml
+++ b/.github/workflows/badge_updater.yml
@@ -24,7 +24,7 @@ jobs:
               "https://api.github.com/orgs/$ORG_NAME/repos?per_page=100&page=$PAGE")
             
             # Filter out archived repos and extract names
-            NAMES=$(echo "$RESPONSE" | jq -r '.[] | select(.archived==false) | .name')
+            NAMES=$(echo "$RESPONSE" | jq -r '.[] | select(.archived==false and .name != ".github") | .name')
             
             # If empty, stop
             if [ -z "$NAMES" ]; then

--- a/.github/workflows/badge_updater.yml
+++ b/.github/workflows/badge_updater.yml
@@ -1,0 +1,62 @@
+name: Badge Updater Orchestration
+
+on:
+  push:
+    paths:
+      - '.github/scripts/update_badges.py' # only trigger org wide updates when this changes
+  workflow_dispatch:
+
+jobs:
+  trigger-all-repos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List all active repos in org
+        id: repos
+        env:
+          ORG_NAME: renalreg
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Fetching all non-archived repos from $ORG_NAME..."
+          PAGE=1
+          REPO_LIST=""
+          while :; do
+            RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/orgs/$ORG_NAME/repos?per_page=100&page=$PAGE")
+            
+            # Filter out archived repos and extract names
+            NAMES=$(echo "$RESPONSE" | jq -r '.[] | select(.archived==false) | .name')
+            
+            # If empty, stop
+            if [ -z "$NAMES" ]; then
+              break
+            fi
+
+            REPO_LIST="$REPO_LIST $NAMES"
+            PAGE=$((PAGE+1))
+          done
+
+          echo "repos=$REPO_LIST" >> $GITHUB_OUTPUT
+          echo "Found active repos: $REPO_LIST"
+
+      - name: Trigger repository_dispatch only if readme_sync.yml exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for repo in ${{ steps.repos.outputs.repos }}; do
+            echo "Checking if $repo has readme_sync.yml..."
+            
+            EXISTS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3.raw" \
+              https://api.github.com/repos/renalreg/$repo/contents/.github/workflows/readme_sync.yml)
+            
+            if [[ $EXISTS != *"Not Found"* ]]; then
+              echo "readme_sync.yml exists in $repo → triggering sync-readme..."
+              curl -X POST \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H "Authorization: token $GITHUB_TOKEN" \
+                https://api.github.com/repos/renalreg/$repo/dispatches \
+                -d '{"event_type":"sync-readme"}'
+            else
+              echo "No readme_sync.yml in $repo → skipping"
+            fi
+          done

--- a/.github/workflows/badge_updater.yml
+++ b/.github/workflows/badge_updater.yml
@@ -3,61 +3,74 @@ name: Badge Updater Orchestration
 on:
   push:
     paths:
-      - '.github/scripts/update_badges.py' # only trigger org wide updates when this changes
+      - '.github/scripts/update_badges.py'
   workflow_dispatch:
 
 jobs:
   trigger-all-repos:
     runs-on: ubuntu-latest
+
     steps:
       - name: List all active repos in org
         id: repos
         env:
           ORG_NAME: renalreg
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_PAT }}
         run: |
           echo "Fetching all non-archived repos from $ORG_NAME..."
+
           PAGE=1
           REPO_LIST=""
+
           while :; do
             RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
               "https://api.github.com/orgs/$ORG_NAME/repos?per_page=100&page=$PAGE")
-            
-            # Filter out archived repos and extract names
+
             NAMES=$(echo "$RESPONSE" | jq -r '.[] | select(.archived==false and .name != ".github") | .name')
-            
-            # If empty, stop
+
             if [ -z "$NAMES" ]; then
               break
             fi
 
-            REPO_LIST="$REPO_LIST $NAMES"
+            # Append as newline list
+            REPO_LIST="$REPO_LIST"$'\n'"$NAMES"
             PAGE=$((PAGE+1))
           done
 
-          echo "repos=$REPO_LIST" >> $GITHUB_OUTPUT
-          echo "Found active repos: $REPO_LIST"
+          echo "Found repos:"
+          echo "$REPO_LIST"
+
+          # Proper multiline output
+          {
+            echo "repos<<EOF"
+            echo "$REPO_LIST"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Trigger repository_dispatch only if readme_sync.yml exists
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_PAT }}
         run: |
-          echo "${{ steps.repos.outputs.repos }}" | while IFS= read -r repo; do
-            echo "Checking if $repo has readme_sync.yml..."
+          while IFS= read -r repo; do
+            [ -z "$repo" ] && continue
+
+            echo "Checking $repo..."
 
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
               -H "Authorization: token $GITHUB_TOKEN" \
               https://api.github.com/repos/renalreg/$repo/contents/.github/workflows/readme_sync.yml)
 
             if [ "$STATUS" = "200" ]; then
-              echo "readme_sync.yml exists in $repo → triggering sync-readme..."
-              curl -X POST \
+              echo "✓ readme_sync.yml exists → dispatching"
+
+              curl -s -X POST \
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Authorization: token $GITHUB_TOKEN" \
                 https://api.github.com/repos/renalreg/$repo/dispatches \
                 -d '{"event_type":"sync-readme"}'
+
             else
-              echo "No readme_sync.yml in $repo → skipping"
+              echo "✗ No workflow → skipping"
             fi
-          done
-      
+
+          done <<< "${{ steps.repos.outputs.repos }}"

--- a/.github/workflows/badge_updater.yml
+++ b/.github/workflows/badge_updater.yml
@@ -42,14 +42,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for repo in ${{ steps.repos.outputs.repos }}; do
+          echo "${{ steps.repos.outputs.repos }}" | while IFS= read -r repo; do
             echo "Checking if $repo has readme_sync.yml..."
-            
-            EXISTS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github.v3.raw" \
+
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: token $GITHUB_TOKEN" \
               https://api.github.com/repos/renalreg/$repo/contents/.github/workflows/readme_sync.yml)
-            
-            if [[ $EXISTS != *"Not Found"* ]]; then
+
+            if [ "$STATUS" = "200" ]; then
               echo "readme_sync.yml exists in $repo → triggering sync-readme..."
               curl -X POST \
                 -H "Accept: application/vnd.github.v3+json" \
@@ -60,3 +60,4 @@ jobs:
               echo "No readme_sync.yml in $repo → skipping"
             fi
           done
+      

--- a/.github/workflows/reusable_badges.yml
+++ b/.github/workflows/reusable_badges.yml
@@ -1,0 +1,47 @@
+name: Reusable README Badge Updater
+
+on:
+  workflow_call:
+    inputs:
+      github_token:
+        required: true
+        type: string
+      pypi_package_name:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      # 1️⃣ Checkout the repo
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main  # or master if your default branch is master
+
+      # 2️⃣ Set up Python
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pyyaml
+      # 3️⃣ Run badge update script
+      - name: Update README badges
+        id: update_readme
+        run: |
+          export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-${{ github.repository }}}"
+          export PYPI_PACKAGE_NAME="${{ inputs.pypi_package_name }}"
+          python3 _shared/.github/scripts/update_badges.py
+      
+
+      # 4️⃣ Commit and push changes directly to main/master
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "Update README badges"
+          branch: main  # commit directly to default branch
+          push: true
+          file_pattern: README.md

--- a/.github/workflows/reusable_badges.yml
+++ b/.github/workflows/reusable_badges.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install pyyaml
+        run: pip install pyyaml click
       # 3️⃣ Run badge update script
       - name: Update README badges
         id: update_readme

--- a/badges.yml
+++ b/badges.yml
@@ -1,0 +1,7 @@
+badges:
+  - '[![Coverage](https://img.shields.io/codecov/c/github/renalreg/radar)](https://codecov.io/gh/renalreg/radar)'
+  - '[![License](https://img.shields.io/github/license/renalreg/radar)](https://github.com/renalreg/radar/blob/main/LICENSE)'
+enable:
+  - 'forks'
+disable:
+  - 'codecov'

--- a/badges.yml
+++ b/badges.yml
@@ -1,7 +1,0 @@
-badges:
-  - '[![Coverage](https://img.shields.io/codecov/c/github/renalreg/radar)](https://codecov.io/gh/renalreg/radar)'
-  - '[![License](https://img.shields.io/github/license/renalreg/radar)](https://github.com/renalreg/radar/blob/main/LICENSE)'
-enable:
-  - 'forks'
-disable:
-  - 'codecov'

--- a/workflow-templates/readme_sync.properties.json
+++ b/workflow-templates/readme_sync.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "readme_sync",
+  "description": "This will sync the readme with org wide badges and info use <div class=badges></div> to denote the location in a readme to update"
+}

--- a/workflow-templates/readme_sync.yml
+++ b/workflow-templates/readme_sync.yml
@@ -1,0 +1,32 @@
+name: Sync README Badges
+
+on:
+  repository_dispatch:
+    types: [sync-readme]
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    uses: renalreg/.github/.github/workflows/reusable_badges.yml@main
+    secrets: inherit
+    #with:
+    # pypi_package_name: "pypi package name"
+
+# you can further customise the badges by adding badges.yml with the following at the same location as the readme.md
+#badges:
+#  - '[![Coverage](https://img.shields.io/codecov/c/github/REPOPATH)](https://codecov.io/gh/REPOPATH)'
+#  - 'any other exact badge'
+#enable:
+#  - ''
+#disable:
+  #- 'codecov'
+  #- 'issues'
+  #- 'dependencies'
+  #- 'vulnerabilities'
+  #- 'license'
+  #- 'stars'
+  #- 'forks'
+  #- 'coverage'
+
+
+


### PR DESCRIPTION
GitHub Repo - "Tidy" Badges

the ticket asked for the RADAR repo to be cleaned up with badges and potential of creating a reusable 'template' for this as such i have created a new workflow.
This should allow all repository READMEs to be updated using a consistent standard, while also supporting enabled and disabled badges.

Badges are only updated organization-wide when update_badges.py is modified.

Badge behavior is controlled by the presence of a badges.yml file, where badges can be enabled, disabled, or hardcoded.
<img width="858" height="1015" alt="image" src="https://github.com/user-attachments/assets/53bd784d-b449-48b6-bc83-98e90018eef6" />
