### PR TITLE
Create PRs for dependencies

### DIFF
--- a/.github/workflows/auto_dependency_pr.yml
+++ b/.github/workflows/auto_dependency_pr.yml
@@ -12,6 +12,9 @@ on:
       target_repo:
         type: string
         default: "rr_validation"
+      reviewers:
+        type: string
+        default: ""
 
 jobs:
   update-main:
@@ -81,4 +84,4 @@ jobs:
             ${{ github.event.pull_request.html_url }}
           committer: bob-dependency-bot <dependency-bob@users.noreply.github.com>
           author: bob-dependency-bot <dependency-bob@users.noreply.github.com>
-          reviewers: GlebRysev-UKKA
+          reviewers: ${{ inputs.reviewers || '' }}

--- a/.github/workflows/auto_dependency_pr.yml
+++ b/.github/workflows/auto_dependency_pr.yml
@@ -1,0 +1,79 @@
+name: Sync PR to Main Repo
+
+on:
+  workflow_call:
+    inputs:
+      base_branch:
+        type: string
+        default: "main"
+      python_versions:
+        type: string
+        default: '["3.12"]'
+      target_repo:
+        type: string
+        default: "rr_validation"
+
+jobs:
+  update-main:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+    
+    steps:
+      - name: Checkout package repo
+        uses: actions/checkout@v4
+
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.REG_APP_ID }}
+          private_key: ${{ secrets.REG_APP_KEY }}
+
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          repository: renalreg/${{ inputs.target_repo }}
+          token: ${{ steps.generate-token.outputs.token }}
+          path: ${{ inputs.target_repo }}
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+
+      - name: Authenticate GitHub HTTPS for private deps
+        run: |
+          git config --global url."https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Update dependency (pin to PR SHA) and lock
+        run: |
+          cd ${{ inputs.target_repo }}
+          PR_SHA="${{ github.event.pull_request.head.sha }}"
+          SRC_REPO="${{ github.repository }}"
+
+          poetry add --lock "git+https://github.com/${SRC_REPO}.git@${PR_SHA}"
+
+      - name: Create or update PR in the main branch
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          path: ${{ inputs.target_repo }}
+          base: ${{ inputs.base_branch }}
+          branch: bump-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
+          commit-message: "Bump ${{ github.event.repository.name }} to PR #${{ github.event.pull_request.number }}"
+          title: "Test ${{ github.event.repository.name }} PR #${{ github.event.pull_request.number }}"
+          body: |
+            Auto-generated PR to test changes from:
+            ${{ github.event.pull_request.html_url }}
+          committer: bob-dependency-bot <dependency-bob@users.noreply.github.com>
+          author: bob-dependency-bot <dependency-bob@users.noreply.github.com>
+          reviewers: GlebRysev-UKKA

--- a/.github/workflows/auto_dependency_pr.yml
+++ b/.github/workflows/auto_dependency_pr.yml
@@ -78,10 +78,24 @@ jobs:
           base: ${{ inputs.base_branch }}
           branch: bump-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
           commit-message: "Bump ${{ github.event.repository.name }} to PR #${{ github.event.pull_request.number }}"
-          title: "Test ${{ github.event.repository.name }} PR #${{ github.event.pull_request.number }}"
+          title: "Bump and test ${{ github.event.repository.name }} PR #${{ github.event.pull_request.number }}"
           body: |
             Auto-generated PR to test changes from:
-            ${{ github.event.pull_request.html_url }}
+            - Source PR: ${{ github.event.pull_request.html_url }}
+            - Source SHA: `${{ github.event.pull_request.head.sha }}`
+            - Package repo: `${{ github.repository }}`
+
+            ## What this PR does
+            This PR pins `${{ github.event.repository.name }}` to the PR SHA above and updates `poetry.lock`.
+
+            ## What to do next 
+            1. Review the dependencies
+            2. Check the CI passes
+            3. Pull locally and build/run 
+
+            ## How to merge 
+            - Merge only after the source PR is approved and ready. 
+            - Alternatively, close this PR once the source PR is merged.
           committer: bob-dependency-bot <dependency-bob@users.noreply.github.com>
           author: bob-dependency-bot <dependency-bob@users.noreply.github.com>
           reviewers: ${{ inputs.reviewers || '' }}

--- a/.github/workflows/auto_dependency_pr.yml
+++ b/.github/workflows/auto_dependency_pr.yml
@@ -77,7 +77,7 @@ jobs:
           path: ${{ inputs.target_repo }}
           base: ${{ inputs.base_branch }}
           branch: bump-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
-          commit-message: "Bump ${{ github.event.repository.name }} to PR #${{ github.event.pull_request.number }}"
+          commit-message: "[skip ci] Bump ${{ github.event.repository.name }} to PR #${{ github.event.pull_request.number }}"
           title: "Bump and test ${{ github.event.repository.name }} PR #${{ github.event.pull_request.number }}"
           body: |
             Auto-generated PR to test changes from:
@@ -90,7 +90,7 @@ jobs:
 
             ## What to do next 
             1. Review the dependencies
-            2. Check the CI passes
+            2. Run CI and check that it passes
             3. Pull locally and build/run 
 
             ## How to merge 

--- a/.github/workflows/auto_dependency_pr.yml
+++ b/.github/workflows/auto_dependency_pr.yml
@@ -15,6 +15,11 @@ on:
 
 jobs:
   update-main:
+    if: >-
+      ${{
+        github.actor != 'dependabot[bot]' &&
+        github.event.pull_request.user.login != 'dependabot[bot]'
+      }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You can also copy and paste the templates into any repo you wish without the nee
 - <a href="#file_check">**UKKA Python File Checker**</a>
 - <a href="#pr_title">**UKKA Conventional PR Title**</a>
 - <a href="#auto_pr">**UKKA Auto Pull Requests**</a>
+- <a href="#auto_dependency_pr">**UKKA Auto Dependency Pull Requests**</a>
 
 <a id="python_test"></a>
 
@@ -177,6 +178,34 @@ Automates the creation and management of pull requests, including branch name ex
 **Consumed Actions**: 
 - [**actions/checkout**](https://github.com/actions/checkout)
 - [**tibdex/github-app-token**](https://github.com/tibdex/github-app-token)
+
+<a id="auto_dependency_pr"></a>
+
+## Auto Dependency PR 
+
+This action automates the creation of PR in repository B, whenever a PR is created in repository A, designed for cases when A is a dependency of B. Runs whenever a PR is opened or changed (e.g., has new commits added to it). 
+
+**Example Options**
+
+```yaml
+with:
+
+  python_versions: '["3.10", "3.11"]'
+  # Description: Python versions to test against
+  # Default: lowest supported Python version
+
+  base_branch: "main"
+  # Description: Name of the base branch in target repo (generally main or master)
+  # Default: "main"
+
+  target_repo: "rr_validation"
+  # Description: Name of the target repo to create PR in (e.g. rr_validation)
+  # Default: "rr_validation"
+
+  reviewers: "GlebRysev-UKKA"
+  # Description: GitHub username of a PR reviewer
+  # Default: "" (no reviewers)
+```
 
 ## Python Test Gen
 

--- a/workflow-templates/auto_dependency_pr.properties.json
+++ b/workflow-templates/auto_dependency_pr.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "UKKA Auto Dependency Pull Requests",
+  "description": "!!Experimental!! Automatically creates a pull request in another repo when PR is created in a current one."
+}

--- a/workflow-templates/auto_dependency_pr.yml
+++ b/workflow-templates/auto_dependency_pr.yml
@@ -24,11 +24,14 @@ jobs:
     #   # Description: Python versions to test against
     #   # Default: lowest supported Python version
     #
-    #
     #   base_branch: "main"
     #   # Description: Name of the base branch in target repo (generally main or master)
     #   # Default: "main"
-
+    #
     #   target_repo: "rr_validation"
     #   # Description: Name of the target repo to create PR in (e.g. rr_validation)
     #   # Default: "rr_validation"
+    #
+    #   reviewers: "GlebRysev-UKKA"
+    #   # Description: GitHub username of a PR reviewer
+    #   # Default: "" (no reviewers)

--- a/workflow-templates/auto_dependency_pr.yml
+++ b/workflow-templates/auto_dependency_pr.yml
@@ -1,0 +1,34 @@
+
+name: Sync PR to Main Repo
+
+on:
+  pull_request:
+    # Fire when PR is opened and updated
+    types: [opened, synchronize, reopened]
+
+  workflow_dispatch:
+
+jobs:
+  call-workflow:
+    name: Sync PR to Main Repo
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    uses: renalreg/.github/.github/workflows/auto_dependency_pr.yml@main
+    secrets: inherit
+
+    # # Optional configuration.
+    # # Uncomment and adjust as required.
+    #
+    # with:
+    #
+    #   python_versions: '["3.10", "3.11"]'
+    #   # Description: Python versions to test against
+    #   # Default: lowest supported Python version
+    #
+    #
+    #   base_branch: "main"
+    #   # Description: Name of the base branch in target repo (generally main or master)
+    #   # Default: "main"
+
+    #   target_repo: "rr_validation"
+    #   # Description: Name of the target repo to create PR in (e.g. rr_validation)
+    #   # Default: "rr_validation"


### PR DESCRIPTION
This will create PRs in a dependent repos whenever a PR is created in a current one. 

Example: [PR in cool_stuff](https://github.com/renalreg/cool_stuff/pull/28), corresponding [PR in rr_validation ](https://github.com/renalreg/rr_validation/pull/26). 

It should ignore PRs from dependabot and skip actions in the main PR (can still be run manually, but I figured that's a decent way to prevent spam).

